### PR TITLE
Add android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ nerdfetch
 - Exherbo Linux
 - Solus Linux
 - macOS 10.x
+- Android
 
 ### Know issues:
 
 - No support for BSD package managers/uptime calculations.
-- Completely breaks on Android due to the fact that /etc/os_release doesn't exist on Android
 - Weird spacing on macOS if you use brew given its complete weirdness
 - In [Cool-Retro-Term](https://github.com/Swordfish90/cool-retro-term), the coffee icon shows up as a Chinese character. To fix this, simply change the default font to a NerdFont you installed, or change the existing coffee icon to `nf-fa-coffee` from the [NerdFonts cheet sheet](https://www.nerdfonts.com/cheat-sheet).

--- a/nerdfetch
+++ b/nerdfetch
@@ -13,7 +13,7 @@ case $ostype in
 	"Linux"*)
 	        if [ -f /bedrock/etc/bedrock-release ]; then
 		 os="$(brl version)"
-		elif [ linuxtype = android ]; then
+		elif [ $linuxtype = android ]; then
 		 os="Android $(getprop ro.build.version.release)"
 		else
 		 os="${PRETTY_NAME}"

--- a/nerdfetch
+++ b/nerdfetch
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 ## OS/ENVIRONMENT INFO DETECTION
-if command -v getprop; then
- ostype=android
+if command -v getprop &> /dev/null; then
+ linuxtype=android
 else
  . /etc/os-release
  ostype="$(uname)"
@@ -13,6 +13,8 @@ case $ostype in
 	"Linux"*)
 	        if [ -f /bedrock/etc/bedrock-release ]; then
 		 os="$(brl version)"
+		elif [ linuxtype = android ]; then
+		 os="Android $(getprop ro.build.version.release)"
 		else
 		 os="${PRETTY_NAME}"
 		fi

--- a/nerdfetch
+++ b/nerdfetch
@@ -28,8 +28,6 @@ case $ostype in
 			esac
 		done < /System/Library/CoreServices/SystemVersion.plist
 		os="macOS ${mac_version}";;
-	"android"*)
-		os="Android $(getprop ro.build.version.release)";;
 	*) os="Idk"
 esac
 

--- a/nerdfetch
+++ b/nerdfetch
@@ -1,11 +1,15 @@
 #!/bin/sh
 
 ## OS/ENVIRONMENT INFO DETECTION
-
-. /etc/os-release
+if ! command -v getprop &> /dev/null; then
+ . /etc/os-release
+ ostype="$(uname)"
+else
+ #this system is android
+ ostype=android
+fi
 kernel="$(uname -r)"
 host="$(cat /proc/sys/kernel/hostname)"
-ostype="$(uname)"
 case $ostype in
 	"Linux"*)
 	        if [ -f /bedrock/etc/bedrock-release ]; then
@@ -23,6 +27,8 @@ case $ostype in
 			esac
 		done < /System/Library/CoreServices/SystemVersion.plist
 		os="macOS ${mac_version}";;
+	"android"*)
+		os="Android $(getprop ro.build.version.release)";;
 	*) os="Idk"
 esac
 

--- a/nerdfetch
+++ b/nerdfetch
@@ -1,12 +1,11 @@
 #!/bin/sh
 
 ## OS/ENVIRONMENT INFO DETECTION
-if ! command -v getprop &> /dev/null; then
+if command -v getprop; then
+ ostype=android
+else
  . /etc/os-release
  ostype="$(uname)"
-else
- #this system is android
- ostype=android
 fi
 kernel="$(uname -r)"
 host="$(cat /proc/sys/kernel/hostname)"

--- a/nerdfetch
+++ b/nerdfetch
@@ -5,8 +5,8 @@ if command -v getprop &> /dev/null; then
  linuxtype=android
 else
  . /etc/os-release
- ostype="$(uname)"
 fi
+ostype="$(uname)"
 kernel="$(uname -r)"
 host="$(cat /proc/sys/kernel/hostname)"
 case $ostype in

--- a/nerdfetch
+++ b/nerdfetch
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## OS/ENVIRONMENT INFO DETECTION
-if command -v getprop &> /dev/null; then
+if command -v getprop > /dev/null; then
  linuxtype=android
 else
  . /etc/os-release


### PR DESCRIPTION
![aaaaaaanerdfe](https://user-images.githubusercontent.com/61617356/102647488-16cdfc80-4166-11eb-8819-8a77b2d85243.png)
This pr checks android version using `getprop ro.build.version.release` which is inbuild android command.
Works even without termux.