### PR TITLE
give `cpm` and `pmm` highter priority over others

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -40,7 +40,13 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm eopkg 2>/dev/null)
+if command -v cpm > /dev/null; then
+	manager=$(which cpm)
+elif command -v pmm > /dev/null; then
+	manager=$(which pmm)
+else
+	manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm eopkg 2>/dev/null)
+fi
 manager=${manager##*/}
 case $manager in
 	cpm) packages="$(cpm C)";;


### PR DESCRIPTION
since both `cpm` and `pmm` are "package managers managers" it would make sense to check first if they are installed and if yes then using them instead of calling package manager itself