### PR TITLE
use all package managers found on system

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -97,8 +97,9 @@ else
 		/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)";;
 		*)
 			packages="$(ls /usr/bin | wc -l)"
-			manager="bin";;
+			manager="bin";;	
 	esac
+	tot="$packages ($manager) "
 fi
 
 ## UPTIME DETECTION

--- a/nerdfetch
+++ b/nerdfetch
@@ -39,10 +39,40 @@ case $ostype in
 esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
-
-managers=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm eopkg 2>/dev/null)
-for manager in $managers
-do
+if [ "$1" = "-a" ]; then
+	managers=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm eopkg 2>/dev/null)
+	for manager in $managers
+	do
+		manager=${manager##*/}
+		case $manager in
+			cpm) packages="$(cpm C)";;
+			brew) packages="$(printf '%s\n' "$(brew --cellar)/"* | wc -l | tr -d '[:space:]')";;
+			port) packages=$(port installed | tot);;
+			apt) packages="$(dpkg-query -f '${binary:Package}\n' -W | wc -l)";;
+			rpm) packages="$(rpm -qa --last| wc -l)";;
+			yum) packages="$(yum list installed | wc -l)";;
+			dnf) packages="$(dnf list installed | wc -l)";;
+			zypper) packages="$(zypper se | wc -l)";;
+			pacman) packages="$(pacman -Q | wc -l)";;
+			yay) packages="$(yay -Q | wc -l)";;
+			paru) packages="$(paru -Q | wc -l)";;
+			kiss) packages="$(kiss list | wc -l)";;
+			pkg|emerge) packages="$(qlist -I | wc -l)";;
+			cave) packages="$(cave show installed-slots | wc -l)";;
+			xbps-query) packages="$(xbps-query -l | wc -l)";;
+			nix-env) packages="$(nix-store -q --requisites /run/current-system/sw | wc -l)";;
+			apk) packages="$(apk list --installed | wc -l)";;
+			pmm) packages="$(/bedrock/libexec/pmm pacman pmm -Q 2>/dev/null | wc -l )";;
+			eopkg) packages="$(eopkg li | wc -l)";;
+			/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)";;
+		*)
+			packages="$(ls /usr/bin | wc -l)"
+			manager="bin";;
+	esac
+	tot="$tot$packages ($manager) "
+	done
+else
+	manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm pmm eopkg 2>/dev/null)
 	manager=${manager##*/}
 	case $manager in
 		cpm) packages="$(cpm C)";;
@@ -65,12 +95,11 @@ do
 		pmm) packages="$(/bedrock/libexec/pmm pacman pmm -Q 2>/dev/null | wc -l )";;
 		eopkg) packages="$(eopkg li | wc -l)";;
 		/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)";;
-	*)
-		packages="$(ls /usr/bin | wc -l)"
-		manager="bin";;
-esac
-tot="$tot$packages ($manager) "
-done
+		*)
+			packages="$(ls /usr/bin | wc -l)"
+			manager="bin";;
+	esac
+fi
 
 ## UPTIME DETECTION
 

--- a/nerdfetch
+++ b/nerdfetch
@@ -40,33 +40,37 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm pmm eopkg 2>/dev/null)
-manager=${manager##*/}
-case $manager in
-	cpm) packages="$(cpm C)";;
-	brew) packages="$(printf '%s\n' "$(brew --cellar)/"* | wc -l | tr -d '[:space:]')";;
-	port) packages=$(port installed | tot);;
-	apt) packages="$(dpkg-query -f '${binary:Package}\n' -W | wc -l)";;
-	rpm) packages="$(rpm -qa --last| wc -l)";;
-	yum) packages="$(yum list installed | wc -l)";;
-	dnf) packages="$(dnf list installed | wc -l)";;
-	zypper) packages="$(zypper se | wc -l)";;
-	pacman) packages="$(pacman -Q | wc -l)";;
-	yay) packages="$(yay -Q | wc -l)";;
-	paru) packages="$(paru -Q | wc -l)";;
-	kiss) packages="$(kiss list | wc -l)";;
-	pkg|emerge) packages="$(qlist -I | wc -l)";;
-	cave) packages="$(cave show installed-slots | wc -l)";;
-	xbps-query) packages="$(xbps-query -l | wc -l)";;
-	nix-env) packages="$(nix-store -q --requisites /run/current-system/sw | wc -l)";;
-	apk) packages="$(apk list --installed | wc -l)";;
-	pmm) packages="$(/bedrock/libexec/pmm pacman pmm -Q 2>/dev/null | wc -l )";;
-	eopkg) packages="$(eopkg li | wc -l)";;
-	/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)";;
+managers=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm eopkg 2>/dev/null)
+for manager in $managers
+do
+	manager=${manager##*/}
+	case $manager in
+		cpm) packages="$(cpm C)";;
+		brew) packages="$(printf '%s\n' "$(brew --cellar)/"* | wc -l | tr -d '[:space:]')";;
+		port) packages=$(port installed | tot);;
+		apt) packages="$(dpkg-query -f '${binary:Package}\n' -W | wc -l)";;
+		rpm) packages="$(rpm -qa --last| wc -l)";;
+		yum) packages="$(yum list installed | wc -l)";;
+		dnf) packages="$(dnf list installed | wc -l)";;
+		zypper) packages="$(zypper se | wc -l)";;
+		pacman) packages="$(pacman -Q | wc -l)";;
+		yay) packages="$(yay -Q | wc -l)";;
+		paru) packages="$(paru -Q | wc -l)";;
+		kiss) packages="$(kiss list | wc -l)";;
+		pkg|emerge) packages="$(qlist -I | wc -l)";;
+		cave) packages="$(cave show installed-slots | wc -l)";;
+		xbps-query) packages="$(xbps-query -l | wc -l)";;
+		nix-env) packages="$(nix-store -q --requisites /run/current-system/sw | wc -l)";;
+		apk) packages="$(apk list --installed | wc -l)";;
+		pmm) packages="$(/bedrock/libexec/pmm pacman pmm -Q 2>/dev/null | wc -l )";;
+		eopkg) packages="$(eopkg li | wc -l)";;
+		/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)";;
 	*)
 		packages="$(ls /usr/bin | wc -l)"
 		manager="bin";;
 esac
+tot="$tot$packages ($manager) "
+done
 
 ## UPTIME DETECTION
 
@@ -171,7 +175,7 @@ ${c0}      ___     ${nc}${USER}${red}@${reset}${hn}${host}${reset}
 ${c0}     (${c1}.. ${c0}\    ${lc}  ${ic}${os}${reset}
 ${c0}     (${c2}<> ${c0}|    ${lc}  ${ic}${kernel}${reset}
 ${c0}    /${c1}/  \\ ${c0}\\   ${lc}  ${ic}${RAM}${memstat} ${mempercent}
-${c0}   ( ${c1}|  | ${c0}/|  ${lc}  ${ic}${packages} (${manager})${reset}
+${c0}   ( ${c1}|  | ${c0}/|  ${lc}  ${ic}${tot}${reset}
 ${c2}  _${c0}/\\ ${c1}__)${c0}/${c2}_${c0})  ${lc}  ${ic}${uptime}${reset}
 ${c2}  \/${c0}-____${c2}\/${reset}   ${lc}  ${red}███${green}███${yellow}███${blue}███${magenta}███${cyan}███${reset}
 EOF


### PR DESCRIPTION
currently nerdfetch uses only first one that it finds
change i made allows it to count package managers in similiarish way to neofetch
![Screenshot_20210310_105449](https://user-images.githubusercontent.com/61617356/110611009-15253b00-818f-11eb-9562-7ceabafb7778.png)
considering it counts both dnf and rpm it may be good idea to remove one of them (propably dnf as rpm is more universal), what do you think?