### PR TITLE
Replace /bin/sh with /usr/bin/env bash

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ## OS/ENVIRONMENT INFO DETECTION
 


### PR DESCRIPTION
Replacing /bin/sh with /usr/bin/env bash for portability