### PR TITLE
Add bulge/yiffOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ curl -fsSL https://raw.githubusercontent.com/ThatOneCalculator/NerdFetch/master/
 - Gentoo Linux
 - Exherbo Linux
 - Solus Linux
-- Slackware Linux\*
 - yiffOS Linux
+- Slackware Linux\*
 - macOS 10.x + 11.x
 - Android
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ curl -fsSL https://raw.githubusercontent.com/ThatOneCalculator/NerdFetch/master/
 - Exherbo Linux
 - Solus Linux
 - Slackware Linux\*
+- yiffOS Linux
 - macOS 10.x + 11.x
 - Android
 

--- a/nerdfetch
+++ b/nerdfetch
@@ -43,7 +43,7 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm pmm eopkg 2>/dev/null)
+manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm pmm eopkg bulge 2>/dev/null)
 manager=${manager##*/}
 case $manager in
 	cpm) packages="$(cpm C)";;
@@ -66,6 +66,7 @@ case $manager in
 	pmm) packages="$(/bedrock/libexec/pmm pacman pmm -Q 2>/dev/null | wc -l )";;
 	eopkg) packages="$(eopkg li | wc -l)";;
 	/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)";;
+	bulge) packages="$(bulge list | wc -l)";;
 	*)
 		packages="$(ls /usr/bin | wc -l)"
 		manager="bin";;

--- a/nerdfetch
+++ b/nerdfetch
@@ -43,7 +43,7 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg yay paru cpm pmm eopkg bulge 2>/dev/null)
+manager=$(which nix-env pkg yum zypper dnf rpm apt brew port pacman xbps-query  emerge cave apk kiss pmm /usr/sbin/slackpkg bulge yay paru cpm pmm eopkg 2>/dev/null)
 manager=${manager##*/}
 case $manager in
 	cpm) packages="$(cpm C)";;


### PR DESCRIPTION
This PR adds [bulge](https://git.yiffos.gay/Packaging/bulge) support in the script and adds [yiffOS](https://yiffos.gay/index.php/Main_Page) as a supported OS to the README.

![image](https://user-images.githubusercontent.com/15057172/144381584-b07afcf8-e4ff-4ee9-83c2-30c73e554995.png)
