### PR TITLE
fix: fix available memory output for NetBSD and use whoami for Android

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -7,7 +7,7 @@ osi=""
 
 distrotype=none
 
-if command -v getprop &> /dev/null; then
+if command -v getprop 1> /dev/null; then
 	distrotype=android
 fi
 kernel="$(echo $(uname -r) | cut -d'-'  -f1-1)"
@@ -15,7 +15,7 @@ case $ostype in
 	*"Linux"*)
 		if [ $distrotype = android ]; then
 			host="$(hostname)"
-			USER=${USER:-$(id -un || printf %s "${HOME/*\/}")}
+			USER="$(whoami)"
 			os="Android $(getprop ro.build.version.release)"
 			osi="󰀲"
 		else
@@ -208,7 +208,7 @@ case $ostype in
 			mem_used=$((mem_used * 4 / 1024));;
 	*"NetBSD"*)
 		mem_full=$(($(/sbin/sysctl -n hw.physmem) / 1024 / 1024))
-		mem_free=$(($(/sbin/sysctl -n vm.stats.vm.v_free_count) * $(/sbin/sysctl -n vm.stats.vm.v_page_size) / 1024 / 1024))
+	        mem_free=$(($(vmstat | awk 'NR==3 {print $4}') / 1024))
 		mem_used=$((mem_full - mem_free));;
 	*"BSD"*)
 		mem_full=$(($(sysctl -n hw.physmem) / 1024 / 1024))


### PR DESCRIPTION
- NetBSD doesn't expose a sysctl entry for available memory and the kernel module isn't callable from shell script. Use vmstat(1) with awk(1) to fix the current issue.

- Replace "USER" variable entry with whoami(1). It seems some shells don't interpret `${$(...)}`, and we can replace this by using whoami(1). It's available in coreutils, and most other Unix-like userlands.

- Only redirect stdout to /dev/null as command -v doesn't give a stderr and only a return value is provided by it. This fixes printing path output of getprop when running NerdFetch on Android.