### PR TITLE
fix package manager detection in `dash` shell

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -186,7 +186,7 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-MANAGER=$(command -v nix-env pkg flatpak yum zypper dnf rpm dpkg-query brew port pacman xbps-query emerge cave apk kiss pmm /usr/sbin/slackpkg bulge birb yay paru pacstall cpm pmm opkg eopkg getprop 2>/dev/null)
+MANAGER=$(for x in nix-env pkg flatpak yum zypper dnf rpm dpkg-query brew port pacman xbps-query emerge cave apk kiss pmm /usr/sbin/slackpkg bulge birb yay paru pacstall cpm pmm opkg eopkg getprop; do command -v $x; done 2>/dev/null)
 manager=$(basename "$MANAGER")
 if [ $distrotype = netbsd ]; then
 	manager="pkg_info-netbsd"


### PR DESCRIPTION
POSIX does not require that `command` accept more than one parameter. Because `dash` silently ignores additional parameters, replacement of `which` with `command -v` resulted in `dash` (which is the default `/bin/sh` on Debian and Ubuntu) ignoring all package managers except `nix-env` (the first one on the list).

This PR resolves the issue by using a `for` loop around `command -v`, which should work in any POSIX shell. `hyperfine` shows this to be just as fast as the previous code, keeping the speedup from dropping `which`.

Reference: https://pubs.opengroup.org/onlinepubs/009696899/utilities/command.html
Resolves: #59