### PR TITLE
always hide seconds when uptime >= 60s

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -270,7 +270,7 @@ else
 	[ "$d" = 0 ] && d=
 	[ "$h" = 0 ] && h=
 	[ "$m" = 0 ] && m=
-	[ "$m" != "" ] && s=
+	[ "$d$h$m" != "" ] && s=
 	# Make the output of uptime smaller.
 	[ "$d" ] && uptime="$d day$dp, "
 	[ "$h" ] && uptime="$uptime$h hour$hp, "


### PR DESCRIPTION
currently seconds are only hidden when minutes>0, but this does not
account for the first minute of each hour

Before:
> ☕  1 day, 2 hours, 93647 secs

After:
>☕  1 day, 2 hours

(I'm sorry for the timing of this, I only noticed this bug after sending my other PRs)