### PR TITLE
fix slackware package detection

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -215,7 +215,7 @@ apk) packages="$(apk list --installed | wc -l)" ;;
 pmm) packages="$(/bedrock/libexec/pmm pacman pmm -Q 2>/dev/null | wc -l)" ;;
 opkg) packages="$(opkg list-installed | wc -l)" ;;
 eopkg) packages="$(eopkg li | wc -l)" ;;
-/usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)" ;;
+slackpkg) packages="$(ls /var/log/packages | wc -l)" ;;
 bulge) packages="$(bulge list | wc -l)" ;;
 birb) packages="$(birb --list-installed | wc -l)" ;;
 pkg_info)


### PR DESCRIPTION
Fix invalid case statement match to make slackpkg detection work

Couldn't get a slackware iso to boot on my computer, but did manage to get a docker image of slackware to run to confirm this is correct. Resolves #65.
```
bash-5.1$ ./nerdfetch  # before

      ___     testuser@slackware
     (.. \      Slackware 15.0 x86_64
     (<> |      5.10.0
    //  \ \   󰍛  13764/128817 MiB (10%)
   ( |  | /|  󰏔  368 (bin)
  _/\ __)/_)  󰅶  3 days, 7 hours, 26 mins
  \/-____\/     ██████████████████
bash-5.1$ ./nerdfetch-patched  # after

      ___     testuser@slackware
     (.. \      Slackware 15.0 x86_64
     (<> |      5.10.0
    //  \ \   󰍛  13787/128817 MiB (10%)
   ( |  | /|  󰏔  60 (slackpkg)
  _/\ __)/_)  󰅶  3 days, 7 hours, 26 mins
  \/-____\/     ██████████████████
bash-5.1$ diff nerdfetch nerdfetch-patched
218c218
< /usr/sbin/slackpkg) packages="$(ls /var/log/packages | wc -l)" ;;
---
> slackpkg) packages="$(ls /var/log/packages | wc -l)" ;;
bash-5.1$ echo $PATH
/usr/local/bin:/bin:/usr/bin
```