### PR TITLE
bug fixes, speed improvements, improve shell support

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -298,6 +298,7 @@ case $ostype in
 	;;
 *"Darwin"*)
 	mem_full=$(($(sysctl -n hw.memsize) / 1024 / 1024))
+	[ $mem_full -gt 0 ] || mem_full=$(expr $(sysctl -n hw.memsize) / 1024 / 1024)
 	while IFS=:. read -r key val _; do
 		case $key in
 		'Anonymous '*|*' wired'* | *' occupied'*)
@@ -311,14 +312,15 @@ case $ostype in
 		$(vm_stat)
 	EOF
 
-	mem_used=$((mem_used * $(sysctl -n vm.pagesize) / 1024 / 1024))
+	mem_used=$((mem_used * ( $(sysctl -n vm.pagesize) / 1024 ) / 1024))
 	;;
 *"BSD"*)
 	mem_full=$(($(sysctl -n hw.physmem) / 1024 / 1024))
+	[ $mem_full -gt 0 ] || mem_full=$(expr $(sysctl -n hw.physmem) / 1024 / 1024)
 	if [ $distrotype = netbsd ]; then
 		mem_free=$(($(vmstat | awk 'NR==3 {print $4}') / 1024))
 	else
-		mem_free=$(($(sysctl -n vm.stats.vm.v_free_count) * $(sysctl -n vm.stats.vm.v_page_size) / 1024 / 1024))
+		mem_free=$(($(sysctl -n vm.stats.vm.v_free_count) * ( $(sysctl -n vm.stats.vm.v_page_size) / 1024 ) / 1024))
 	fi
 	mem_used=$((mem_full - mem_free))
 	;;


### PR DESCRIPTION
This is a bit of a catch-all. I kept each commit discrete by topic, but there are several topics covered in this PR. Each commit should apply cleanly in any order, so if you don't like all of them, feel free to mix and match. Or, if you prefer, I could resubmit them as more than one PR.

## faster
hyperfine results:

| macos |   before                 | after                          |  percent |
| ------ | ------------------ | ------------------- | -------- |
| dash | 42.0 ms ±   1.1 ms   | 35.1 ms ±   0.6 ms  |  16%    |
| bash | 44.3 ms ±   0.5 ms |  36.9 ms ±   0.5 ms |  16%    |
| zsh  | 45.9 ms ±   1.0 ms   | 38.7 ms ±   0.8 ms  |  16%    |


| debian 12 |   before                 | after                  |  percent |
| ------ | ------------------ | ----------------- | ---------|
| dash | 6.4 ms ±   0.9 ms   | 4.2 ms ±   0.6 ms  |  34%     |
| bash | 8.2 ms ±   1.0 ms |  5.2 ms ±   0.7 ms    |  36%      |
| zsh  | 8.6 ms ±   1.0 ms   | 5.6 ms ±   0.8 ms    |  35%      |

## fixed compatibility with zsh, osh, mksh
before:
```
NerdFetch % zsh nerdfetch
expr: not a decimal number: '53562.25'
expr: syntax error

      ___     rrotter@mond
     (.. \      macOS 15.5
     (<> |      24.5.0
    //  \ \   󰍛  53562.25/65536 MiB (%)
   ( |  | /|  󰏔  104 (brew)
  _/\ __)/_)  󰅶  10 days, 6 hours, 53 mins
  \/-____\/     ██████████████████
NerdFetch % osh nerdfetch
getprop: not found
  283583.
        ^
./nerdfetch:1: Unexpected token while parsing arithmetic: '.'
  283583.
        ^
./nerdfetch:1: fatal: Parse error in recursive arithmetic
NerdFetch % mksh nerdfetch
expr: division by zero
expr: syntax error

      ___     rrotter@mond
     (.. \      macOS 15.5
     (<> |      24.5.0
    //  \ \   󰍛  367/0 MiB (%)
   ( |  | /|  󰏔  104 (brew)
  _/\ __)/_)  󰅶  10 days, 6 hours, 53 mins
  \/-____\/     ██████████████████
```

after:
```
NerdFetch % zsh nerdfetch; osh nerdfetch; mksh nerdfetch

      ___     rrotter@mond
     (.. \      macOS 15.5
     (<> |      24.5.0
    //  \ \   󰍛  53832/65536 MiB (82)%
   ( |  | /|  󰏔  104 (brew)
  _/\ __)/_)  󰅶  10 days, 7 hours, 33 mins
  \/-____\/     ██████████████████

      ___     rrotter@mond
     (.. \      macOS 15.5
     (<> |      24.5.0
    //  \ \   󰍛  53847/65536 MiB (82)%
   ( |  | /|  󰏔  104 (brew)
  _/\ __)/_)  󰅶  10 days, 7 hours, 33 mins
  \/-____\/     ██████████████████

      ___     rrotter@mond
     (.. \      macOS 15.5
     (<> |      24.5.0
    //  \ \   󰍛  53832/65536 MiB (82)%
   ( |  | /|  󰏔  104 (brew)
  _/\ __)/_)  󰅶  10 days, 7 hours, 33 mins
  \/-____\/     ██████████████████
```
