### PR TITLE
Feature easier help args

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -45,7 +45,7 @@ case $1 in
 	echo "NerdFetch $version"
 	exit
 	;;
-"-"[a-z]*)
+"-"[a-z]* | "--"[a-z]*)
 	echo "Flags:
 -c: Cozette font
 -p: Phosphor font

--- a/nerdfetch
+++ b/nerdfetch
@@ -45,12 +45,13 @@ case $1 in
 	echo "NerdFetch $version"
 	exit
 	;;
-"-h")
+"-"[a-z]*)
 	echo "Flags:
 -c: Cozette font
 -p: Phosphor font
 -e: Emoji font
--v: Version"
+-v: Version
+-h: Display help menu"
 	exit
 	;;
 esac


### PR DESCRIPTION
Made all wrong - and -- flags point to the -h flags menu. Not useful but I initially ran `--help` and I'd expect that to also show the flags menu.