### PR TITLE
fix: use /etc/NIXOS tag for nixos

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -57,7 +57,7 @@ esac
 
 if command -v getprop 1>/dev/null 2>&1; then
 	distrotype=android
-elif [ -f /etc/nixos/configuration.nix ]; then
+elif [ -f /etc/NIXOS ]; then
     distrotype=nixos
 fi
 kernel=$(uname -r)


### PR DESCRIPTION
instead of the insane approch of checking for
`/etc/nixos/configuration.nix` which most certianly will not exist on every system we can check for `/etc/NIXOS` which should account for 99.99% of nixos systems.

ref:
https://github.com/NixOS/nixpkgs/blob/4863a18f03194a06deb782d1115d7dbbe2af2c91/nixos/modules/system/etc/setup-etc.pl#L155-L159