### PR TITLE
fix: work with no /etc/os-release file

### DIFF
--- a/nerdfetch
+++ b/nerdfetch
@@ -75,11 +75,16 @@ case $ostype in
 		esac
 	else
 		host="$(cat /proc/sys/kernel/hostname)"
-		. /etc/os-release
+		if [ -f /etc/os-release ]; then
+			. /etc/os-release
+		else
+			PRETTY_NAME="Unknown Linux"
+			ID="linux"
+		fi
 		if [ -f /bedrock/etc/bedrock-release ]; then
 			os="$(brl version)"
 		else
-			os="${PRETTY_NAME}"
+			os="${PRETTY_NAME:-Unknown Linux}"
 			if [ $font = nerd ]; then
 				case ${ID%% *} in
 				debian) osi="" ;;

--- a/nerdfetch
+++ b/nerdfetch
@@ -75,10 +75,10 @@ case $ostype in
 		esac
 	else
 		host="$(cat /proc/sys/kernel/hostname)"
-		if [ -f /etc/os-release ]; then
+		if [ -r /etc/os-release ]; then
 			. /etc/os-release
 		else
-			PRETTY_NAME="Unknown Linux"
+			PRETTY_NAME="Linux"
 			ID="linux"
 		fi
 		if [ -f /bedrock/etc/bedrock-release ]; then


### PR DESCRIPTION
Is some cases /etc/os-release just don't exist:
```
$ sh nerdfetch
nerdfetch: .: line 187: can't open '/etc/os-release'
```
Yes, it's small chance, but why not to fix it?